### PR TITLE
Enhance Sentry symbol upload configuration and environment variable h…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,14 +12,29 @@ def reseller = System.getenv("RESELLERNAME")
 println "Reseller name: ${reseller}"
 
 def sentryToken =  System.getenv("SENTRY_AUTH_TOKEN")
-println "Sentry auth token: ${sentryToken?.length()}"
+def sentryUploadEnabled = sentryToken != null && !sentryToken.trim().isEmpty()
+println "Sentry auth token: ${sentryToken?.length()}, symbol upload enabled: ${sentryUploadEnabled}"
 
 
 sentry {
-    includeSourceContext = true
     org = "dimensions-technologies"
     projectName = "connect-android"
     authToken = sentryToken
+
+    // Upload the R8/ProGuard mapping file so minified Kotlin/Java stack traces are deobfuscated.
+    includeProguardMapping = true
+    autoUploadProguardMapping = sentryUploadEnabled
+
+    // Bundle and upload source files so Sentry can show source context around each frame.
+    includeSourceContext = sentryUploadEnabled
+
+    // Upload the native (.so) debug symbols for the linphone-sdk so NDK crashes are symbolicated.
+    uploadNativeSymbols = sentryUploadEnabled
+    autoUploadNativeSymbols = sentryUploadEnabled
+    includeNativeSources = sentryUploadEnabled
+
+    // Debug builds are never shipped, so don't spend build time uploading their symbols.
+    ignoredBuildTypes = ["debug"]
 }
 
 def appVersionName = "5.3.0"

--- a/build-ci.yml
+++ b/build-ci.yml
@@ -2,10 +2,13 @@ name: $(MAJOR).$(MINOR).$(YEAR:yy)$(DAYOFYEAR).$(REV:r)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  artifactName: 'apk-release'
-  resellerName: 'Dimensions Technologies'
-
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: artifactName
+  value: 'apk-release'
+- name: resellerName
+  value: 'Dimensions Technologies'
 stages:
 - stage: Build
 
@@ -79,9 +82,9 @@ stages:
           publishJUnitResults: false
           javaHomeOption: 'JDKVersion'
           sonarQubeRunAnalysis: false
-          spotBugsAnalysis: false#
+          spotBugsAnalysis: false
         env:
-          SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+          SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
       - task: PublishBuildArtifacts@1
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build-release-brytecall.yml
+++ b/build-release-brytecall.yml
@@ -2,10 +2,13 @@ name: $(Build.SourceBranchName)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  baseFolder: '$(Build.SourcesDirectory)/app/src/bryteCall'
-  resellerName: 'BryteCall'
-  
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: baseFolder
+  value: '$(Build.SourcesDirectory)/app/src/bryteCall'
+- name: resellerName
+  value: 'BryteCall'
 steps:
 - checkout: self
 
@@ -124,7 +127,7 @@ steps:
     sonarQubeRunAnalysis: false
     spotBugsAnalysis: false
   env:
-    SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+    SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build-release-ipintegration.yml
+++ b/build-release-ipintegration.yml
@@ -2,10 +2,13 @@ name: $(Build.SourceBranchName)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  baseFolder: '$(Build.SourcesDirectory)/app/src/ecx'
-  resellerName: 'IP Integration'
-  
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: baseFolder
+  value: '$(Build.SourcesDirectory)/app/src/ecx'
+- name: resellerName
+  value: 'IP Integration'
 steps:
 - checkout: self
 
@@ -124,7 +127,7 @@ steps:
     sonarQubeRunAnalysis: false
     spotBugsAnalysis: false
   env:
-    SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+    SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build-release-voyager.yml
+++ b/build-release-voyager.yml
@@ -2,10 +2,13 @@ name: $(Build.SourceBranchName)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  baseFolder: '$(Build.SourcesDirectory)/app/src/voyager'
-  resellerName: 'Voyager Internet'
-
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: baseFolder
+  value: '$(Build.SourcesDirectory)/app/src/voyager'
+- name: resellerName
+  value: 'Voyager Internet'
 steps:
 - checkout: self
 
@@ -124,7 +127,7 @@ steps:
     sonarQubeRunAnalysis: false
     spotBugsAnalysis: false
   env:
-    SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+    SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build-release-vpbx.yml
+++ b/build-release-vpbx.yml
@@ -2,10 +2,13 @@ name: $(Build.SourceBranchName)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  baseFolder: '$(Build.SourcesDirectory)/app/src/vpbx'
-  resellerName: 'VirtualPBX'
-  
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: baseFolder
+  value: '$(Build.SourcesDirectory)/app/src/vpbx'
+- name: resellerName
+  value: 'VirtualPBX'
 steps:
 - checkout: self
 
@@ -124,7 +127,7 @@ steps:
     sonarQubeRunAnalysis: false
     spotBugsAnalysis: false
   env:
-    SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+    SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build-release.yml
+++ b/build-release.yml
@@ -2,9 +2,11 @@ name: $(Build.SourceBranchName)
 pool:
   vmImage: 'ubuntu-latest'
 variables:
-  appVersionCode: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
-  resellerName: 'Dimensions Technologies'
-          
+- group: Sentry-Symbol-Upload
+- name: appVersionCode
+  value: $(MAJOR)$(MINOR)$(YEAR:yy)$(DAYOFYEAR)$(REV:r)
+- name: resellerName
+  value: 'Dimensions Technologies'
 steps:
 - checkout: self
 
@@ -107,7 +109,7 @@ steps:
     sonarQubeRunAnalysis: false
     spotBugsAnalysis: false
   env:
-    SENTRY_AUTH_TOKEN: $(SentryAuthToken) # Map secret variable SentryAuthToken to an environment variable
+    SENTRY_AUTH_TOKEN: $(sentryAuthToken) # Secret from the Sentry-Symbol-Upload variable group
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
Upload Sentry symbols from the build pipelines

Sentry issues were unsymbolicated because no pipeline linked the
Sentry-Symbol-Upload variable group, so the SENTRY_AUTH_TOKEN env
mapping resolved to nothing and every upload silently no-opped.

Link the variable group in all six release/CI pipelines (converting
the root variables mapping to list syntax, which mixing a group with
named variables requires) and point the env mapping at the group's
sentryAuthToken.

Expand the Gradle sentry block to actually upload what symbolication
needs: the R8 mapping file for the minified Kotlin/Java frames and the
native debug symbols for NDK frames. Uploads are gated on the token
being present so local builds without it still work, and debug is
ignored since it is never shipped.

Also drop a stray '#' in build-ci.yml that made YAML parse
spotBugsAnalysis as the string "false#" rather than a boolean.