### PR TITLE
Limit Sentry to crashes and errors, and fix the CI failure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,13 +25,20 @@ sentry {
     includeProguardMapping = true
     autoUploadProguardMapping = sentryUploadEnabled
 
-    // Bundle and upload source files so Sentry can show source context around each frame.
-    includeSourceContext = sentryUploadEnabled
-
     // Upload the native (.so) debug symbols for the linphone-sdk so NDK crashes are symbolicated.
     uploadNativeSymbols = sentryUploadEnabled
     autoUploadNativeSymbols = sentryUploadEnabled
-    includeNativeSources = sentryUploadEnabled
+
+    // Do not upload source. The mapping file alone gives file, line and method names;
+    // source context would put this repository's code in Sentry for no extra readability.
+    includeSourceContext = false
+    includeNativeSources = false
+
+    // The plugin adds performance instrumentation by default, rewriting bytecode to add
+    // tracing spans. Scope here is crashes and errors only, so it stays off.
+    tracingInstrumentation {
+        enabled = false
+    }
 
     // Debug builds are never shipped, so don't spend build time uploading their symbols.
     ignoredBuildTypes = ["debug"]

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,27 +74,56 @@
         android:allowNativeHeapPointerTagging="false">
 
         <!-- Sentry.io config -->
+        <!--
+            Scope is deliberately limited to crashes and errors. Performance tracing,
+            profiling, session replay and release health are all off by explicit choice,
+            not by oversight - this is a softphone, so screen and network telemetry
+            carries contact names, phone numbers and SIP signalling. Do not re-enable
+            any of these without a decision about what that data contains.
+        -->
         <meta-data android:name="io.sentry.dsn"
             android:value="https://540d9cdc3bf9045bb7b414ea2fed683b@o4509371926446080.ingest.de.sentry.io/4509412243079248" />
-        <!-- Add data like request headers, user ip address and device name, see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info -->
-        <meta-data android:name="io.sentry.send-default-pii" android:value="true" />
-        <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
-        <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
-        <!-- enable screenshot for crashes -->
+
+        <!-- Sentry is initialised explicitly in LinphoneApplication.onCreate so the
+             event processor is registered before any activity starts. -->
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+
+        <!-- Do not send user IP, device name or request headers. -->
+        <meta-data android:name="io.sentry.send-default-pii" android:value="false" />
+
+        <!-- Visual context on crash events. Kept deliberately; these fire on errors only. -->
         <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
-        <!-- enable view hierarchy for crashes -->
         <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
-        <!-- enable the performance API by setting a sample-rate, adjust in production env -->
-        <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-        <!-- Enable UI profiling, adjust in production env. This is evaluated only once per session -->
-        <meta-data android:name="io.sentry.traces.profiling.session-sample-rate" android:value="1.0" />
-        <!-- Set profiling mode. For more info see https://docs.sentry.io/platforms/android/profiling/#enabling-ui-profiling -->
-        <meta-data android:name="io.sentry.traces.profiling.lifecycle" android:value="trace" />
-        <!-- Enable profiling on app start. The app start profile will be stopped automatically when the app start root span finishes -->
-        <meta-data android:name="io.sentry.traces.profiling.start-on-app-start" android:value="true" />
-        <!-- record session replays for 100% of errors and 10% of sessions -->
-        <meta-data android:name="io.sentry.session-replay.on-error-sample-rate" android:value="1.0" />
-        <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="0.1" />
+
+        <!-- Performance tracing and profiling: off. Not a crash signal. -->
+        <meta-data android:name="io.sentry.traces.sample-rate" android:value="0.0" />
+        <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
+        <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="false" />
+        <meta-data android:name="io.sentry.traces.frames-tracking" android:value="false" />
+        <meta-data android:name="io.sentry.traces.profiling.session-sample-rate" android:value="0.0" />
+        <meta-data android:name="io.sentry.traces.profiling.start-on-app-start" android:value="false" />
+        <meta-data android:name="io.sentry.profiling.enable-app-start" android:value="false" />
+
+        <!-- Session Replay records the screen. Off, not sampled down. -->
+        <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="0.0" />
+        <meta-data android:name="io.sentry.session-replay.on-error-sample-rate" android:value="0.0" />
+
+        <!-- Release health / session tracking: off. Not a crash signal. -->
+        <meta-data android:name="io.sentry.auto-session-tracking.enable" android:value="false" />
+
+        <!-- ANR reports "application not responding" - a latency signal, not a crash. -->
+        <meta-data android:name="io.sentry.anr.enable" android:value="false" />
+
+        <!--
+            Automatic breadcrumbs sit below wherever this app redacts sensitive strings,
+            so they can capture SIP data the logging layer would have scrubbed. Off.
+        -->
+        <meta-data android:name="io.sentry.breadcrumbs.app-lifecycle" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.activity-lifecycle" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.system-events" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.network-events" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.app-components" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="false" />
 
         <!-- ENTRY POINT -->
         <activity

--- a/app/src/main/java/org/linphone/LinphoneApplication.kt
+++ b/app/src/main/java/org/linphone/LinphoneApplication.kt
@@ -31,9 +31,11 @@ import coil.decode.VideoFrameDecoder
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import com.jakewharton.threetenabp.AndroidThreeTen
+import io.sentry.android.core.SentryAndroid
 import org.linphone.core.*
 import org.linphone.mediastream.Version
 import org.linphone.middleware.FileTree
+import org.linphone.middleware.SentryEventProcessor
 import org.linphone.utils.Log
 import timber.log.Timber
 
@@ -115,6 +117,14 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
         val appName = getString(R.string.app_name)
+
+        // Initialised here rather than in an activity so that crashes during startup are
+        // reported, and so the event processor is registered before any event can be sent.
+        // Auto-init is disabled in the manifest to keep this the only initialisation.
+        // Scope (crashes and errors only) is configured via manifest meta-data.
+        SentryAndroid.init(this) { options ->
+            options.addEventProcessor(SentryEventProcessor(this))
+        }
 
         Timber.plant(Timber.DebugTree(), FileTree(applicationContext))
         Timber.tag("cloud.dimensions.uconnect")

--- a/app/src/main/java/org/linphone/activities/main/MainActivity.kt
+++ b/app/src/main/java/org/linphone/activities/main/MainActivity.kt
@@ -52,7 +52,6 @@ import coil.imageLoader
 import com.google.android.material.snackbar.Snackbar
 import com.google.gson.Gson
 import io.reactivex.rxjava3.subjects.PublishSubject
-import io.sentry.android.core.SentryAndroid
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import kotlin.math.abs
@@ -91,7 +90,6 @@ import org.linphone.core.Core
 import org.linphone.core.CoreListenerStub
 import org.linphone.core.CorePreferences
 import org.linphone.databinding.MainActivityBinding
-import org.linphone.middleware.SentryEventProcessor
 import org.linphone.models.AuthenticatedUser
 import org.linphone.services.UserService
 import org.linphone.utils.AppUtils
@@ -177,11 +175,6 @@ class MainActivity : GenericActivity(), SnackBarActivity, NavController.OnDestin
         super.onCreate(savedInstanceState)
 
         Log.i("Auth: onCreate MainActivity")
-
-        SentryAndroid.init(this, {
-                options ->
-            options.addEventProcessor(SentryEventProcessor(this))
-        })
 
         enableEdgeToEdge(
             SystemBarStyle.dark(Color.TRANSPARENT),

--- a/app/src/main/java/org/linphone/middleware/SentryEventProcessor.kt
+++ b/app/src/main/java/org/linphone/middleware/SentryEventProcessor.kt
@@ -11,12 +11,17 @@ import org.linphone.utils.Log
 class SentryEventProcessor(private val context: Context) : EventProcessor {
 
     override fun process(event: SentryEvent, hint: Hint): SentryEvent? {
-        try {
-            val zipFile = DiagnosticsService.getLogsZip(context)
-            hint.clearAttachments()
-            hint.addAttachment(Attachment(zipFile.path))
-        } catch (ex: Exception) {
-            Log.e(ex, "Failed to append log files to Sentry event.")
+        // Only attach diagnostics to genuine crashes. The zip contains SIP signalling and
+        // phone numbers, so it is deliberately not sent with every handled error - the
+        // volume of exposure is the point, not whether any single event needs it.
+        if (event.isCrashed) {
+            try {
+                val zipFile = DiagnosticsService.getLogsZip(context)
+                hint.clearAttachments()
+                hint.addAttachment(Attachment(zipFile.path))
+            } catch (ex: Exception) {
+                Log.e(ex, "Failed to append log files to Sentry event.")
+            }
         }
 
         return super.process(event, hint)


### PR DESCRIPTION
Build 74168 failed on sentryUploadSourceBundleRelease: 734 source files were bundled and the upload then hung for 15 minutes before Sentry's gateway returned 504 Downstream timeout. That was ~15 of the build's 16 minutes, and it killed the run after the AAB had already been built and signed, so no artifact was published. The mapping file and all 60 native debug files had uploaded successfully before it.

Turn source context off. The mapping alone already gives file, line and method names, so it bought little readability, and includeNativeSources resolved source for 0 of 60 files anyway because the linphone-sdk ships stripped .so files.

The rest of this commit narrows the integration to crashes and errors, which is what it should have been reporting all along. Session replay (which records the screen), performance tracing, profiling, release health, ANR detection and all six automatic breadcrumb categories are now off, and send-default-pii is false. This is a softphone: screen and breadcrumb telemetry carries contact names, phone numbers and SIP signalling, and breadcrumbs in particular sit below the layer where the app redacts sensitive strings. Screenshot and view-hierarchy capture are kept deliberately - they fire on error events only.

Manifest keys were checked against ManifestMetadataReader in the SDK source rather than the docs, since a misspelled key fails silently.

Two bugs found while auditing:

Sentry was initialised twice - once automatically from the manifest DSN at process start, then again in MainActivity.onCreate. The second init was also too late to matter: the manifest entry point is LoginActivity, so SentryEventProcessor was not registered until a user reached the main screen and any earlier crash was reported without it. Auto-init is now disabled and the single init happens in LinphoneApplication.onCreate.

The diagnostics log zip was attached to every event. It now goes only with genuine crashes.

Also disables the plugin's tracingInstrumentation, which rewrites bytecode to add tracing spans and was the source of the ASM "wasn't able to resolve some classes" warning.